### PR TITLE
Add support for polling mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# NOTE! Don't add files that are generated in specific
+# subdirectories here. Add them in the ".gitignore" file
+# in that subdirectory instead.
+#
+# NOTE! Please use 'git ls-files -i --exclude-standard'
+# command after changing this file, to see if there are
+# any tracked files which get ignored after the change.
+#
+# Normal rules (sorted alphabetically)
+#
+.*
+*.a
+*.asn1.[ch]
+*.bin
+*.bz2
+*.c.[012]*.*
+*.dt.yaml
+*.dtb
+*.dtbo
+*.dtb.S
+*.dwo
+*.elf
+*.gcno
+*.gz
+*.i
+*.ko
+*.lex.c
+*.ll
+*.lst
+*.lz4
+*.lzma
+*.lzo
+*.mod
+*.mod.c
+*.o
+*.o.*
+*.patch
+*.s
+*.so
+*.so.dbg
+*.su
+*.symtypes
+*.symversions
+*.tab.[ch]
+*.tar
+*.usyms
+*.xz
+*.zst
+Module.symvers
+modules.order
+
+#
+# Top-level generic files
+#
+/linux
+/modules-only.symvers
+/vmlinux
+/vmlinux.32
+/vmlinux.map
+/vmlinux.symvers
+/vmlinux-gdb.py
+/vmlinuz
+/System.map
+/Module.markers
+/modules.builtin
+/modules.builtin.modinfo
+/modules.nsdeps
+
+#
+# RPM spec file (make rpm-pkg)
+#
+/*.spec
+
+#
+# Debian directory (make deb-pkg)
+#
+/debian/
+
+#
+# Snap directory (make snap-pkg)
+#
+/snap/
+
+#
+# tar directory (make tar*-pkg)
+#
+/tar-install/
+
+#
+# We don't want to ignore the following even if they are dot-files
+#
+!.clang-format
+!.cocciconfig
+!.get_maintainer.ignore
+!.gitattributes
+!.gitignore
+!.mailmap
+
+#
+# Generated include files
+#
+/include/config/
+/include/generated/
+/include/ksym/
+/arch/*/include/generated/
+
+# stgit generated dirs
+patches-*
+
+# quilt's files
+patches
+series
+
+# ctags files
+tags
+TAGS
+
+# cscope files
+cscope.*
+ncscope.*
+
+# gnu global files
+GPATH
+GRTAGS
+GSYMS
+GTAGS
+
+# id-utils files
+ID
+
+*.orig
+*~
+\#*#
+
+#
+# Leavings from module signing
+#
+extra_certificates
+signing_key.pem
+signing_key.priv
+signing_key.x509
+x509.genkey
+
+# Kconfig presets
+/all.config
+/alldef.config
+/allmod.config
+/allno.config
+/allrandom.config
+/allyes.config
+
+# Kconfig savedefconfig output
+/defconfig
+
+# Kdevelop4
+*.kdev4
+
+# Clang's compilation database file
+/compile_commands.json
+
+# Documentation toolchain
+sphinx_*/

--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,8 @@ axiom_i2c-objs := axiom_core.o axiom_i2c_comms.o
 all:
 	$(MAKE) -C $(KERNEL_LOC) M=$(PWD) modules
 
+install:
+	$(MAKE) -C $(KERNEL_LOC) M=$(PWD) modules_install
+
 clean:
 	$(MAKE) -C $(KERNEL_LOC) M=$(PWD) clean

--- a/axiom_core.h
+++ b/axiom_core.h
@@ -153,6 +153,6 @@ extern void axiom_remove(struct axiom_data_core *data_core);
 extern void axiom_process_report(struct axiom_data_core *data_core, u8 *pReport);
 extern void axiom_process_u41_report(u8 *rx_buf, struct axiom_data_core *data_core);
 extern void axiom_process_u46_report(u8 *rx_buf, struct axiom_data_core *data_core);
-extern struct input_dev *axiom_register_input_subsystem(void);
+extern struct input_dev *axiom_register_input_subsystem(bool poll_enable, int poll_interval);
 
 #endif  /* __AXIOM_CORE_H */

--- a/axiom_usb_comms.c
+++ b/axiom_usb_comms.c
@@ -424,7 +424,7 @@ static int axiom_usb_probe(struct hid_device *hdev,
 		goto abort;
 	}
 
-	data_core->input_dev = axiom_register_input_subsystem();
+	data_core->input_dev = axiom_register_input_subsystem(0, 0);
 	if (data_core->input_dev == NULL) {
 		hid_err(hdev, "ERROR: Failed to register input device, error: %d\n", ret);
 		goto abort;


### PR DESCRIPTION
Hello,

This small series mainly intend to add support for the polling mode for i2c and spi based interface as some platforms (e.g
X86 based platforms) might not provide GPIOs to work in irq mode.

We also introduced some gitignore files and a new makefile target to install the module.

Regards,
Kamel BOUHARA, Bootlin
Embedded Linux and kernel engineering
https://bootlin.com
