### PR TITLE
Fix probe() API change for kernel > v6.3

### DIFF
--- a/axiom_i2c_comms.c
+++ b/axiom_i2c_comms.c
@@ -19,6 +19,7 @@
 //#define DEBUG   // Enable debug messages
 
 #include <linux/kernel.h>
+#include <linux/version.h>
 #include <linux/kobject.h>
 #include <linux/delay.h>
 #include <linux/input.h>
@@ -125,8 +126,15 @@ static irqreturn_t axiom_irq(int irq, void *handle)
 
 // purpose: Function called in IRQ context when device is plugged in.
 // returns: Error code
+#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
+static int axiom_i2c_probe(struct i2c_client *i2cClient)
+#else
 static int axiom_i2c_probe(struct i2c_client *i2cClient, const struct i2c_device_id *id)
+#endif
 {
+#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
+	const struct i2c_device_id *id = i2c_client_get_device_id(i2cClient);
+#endif
 	struct device *pDev = &i2cClient->dev;
 	struct axiom_data *data;
 	struct axiom_data_core *data_core;


### PR DESCRIPTION
Upstream commit [`03c835f498b5 ("i2c: Switch .probe() to not take an id parameter")`](https://github.com/torvalds/linux/commit/03c835f498b5) removed the `i2c_device_id parameter` from `.probe()` function.

Add proper definition for `axiom_i2c_probe()` function, and make is compile-dependent on the kernel version.

_NOTE_: Following warnings are produced by `checkpatch.pl` which can be ignored:
```
179e6ff275fdd3155b040156e1b14045ef2aa7a3:6: WARNING: Unknown commit id '03c835f498b5', maybe rebased or not pulled?
```
This is related to commit message, which refers to commit in Kernel tree where the I2C API change happened.

```
179e6ff275fdd3155b040156e1b14045ef2aa7a3:33: WARNING: LINUX_VERSION_CODE should be avoided, code should be for the version to which it is merged
179e6ff275fdd3155b040156e1b14045ef2aa7a3:39: WARNING: LINUX_VERSION_CODE should be avoided, code should be for the version to which it is merged
```
This is unfortunately required in order to provide a possibility to build this OOT module for both mainline and LTS (`v.6.1.y`) kernels. Once driver would land in upstream, conditional compilation can be fully omitted.

```
179e6ff275fdd3155b040156e1b14045ef2aa7a3:34: CHECK: Avoid CamelCase: <i2cClient>
```
This is present in the original code, and left untouched as changing this would be is unrelated to this PR.

-- andrey