### PR TITLE
api changes i2c spi remove function

### DIFF
--- a/axiom_i2c_comms.c
+++ b/axiom_i2c_comms.c
@@ -212,7 +212,7 @@ static int axiom_i2c_probe(struct i2c_client *i2cClient, const struct i2c_device
 }
 
 // purpose: Clean-up when device is disconnected
-#if(LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0))
+#if (KERNEL_VERSION(6, 1, 0) > LINUX_VERSION_CODE)
 static int axiom_i2c_remove(struct i2c_client *i2cClient)
 #else
 static void axiom_i2c_remove(struct i2c_client *i2cClient)
@@ -234,7 +234,7 @@ static void axiom_i2c_remove(struct i2c_client *i2cClient)
 
 	dev_info(&i2cClient->dev, "Removed\n");
 
-#if(LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0))
+#if (KERNEL_VERSION(6, 1, 0) > LINUX_VERSION_CODE)
 	return 0;
 #endif
 }

--- a/axiom_i2c_comms.c
+++ b/axiom_i2c_comms.c
@@ -29,7 +29,6 @@
 #include <linux/pm.h>
 #include <linux/i2c.h>
 #include <linux/string.h>
-#include <linux/version.h>
 #include "axiom_core.h"
 
 static bool poll_enable;

--- a/axiom_i2c_comms.c
+++ b/axiom_i2c_comms.c
@@ -29,6 +29,7 @@
 #include <linux/pm.h>
 #include <linux/i2c.h>
 #include <linux/string.h>
+#include <linux/version.h>
 #include "axiom_core.h"
 
 static bool poll_enable;
@@ -211,7 +212,11 @@ static int axiom_i2c_probe(struct i2c_client *i2cClient, const struct i2c_device
 }
 
 // purpose: Clean-up when device is disconnected
+#if(LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0))
+static int axiom_i2c_remove(struct i2c_client *i2cClient)
+#else
 static void axiom_i2c_remove(struct i2c_client *i2cClient)
+#endif
 {
 	struct axiom_data *data;
 	struct axiom_data_core *data_core;
@@ -228,6 +233,10 @@ static void axiom_i2c_remove(struct i2c_client *i2cClient)
 	axiom_remove(data_core);
 
 	dev_info(&i2cClient->dev, "Removed\n");
+
+#if(LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0))
+	return 0;
+#endif
 }
 
 static const struct i2c_device_id axiom_i2c_id_table[] = {

--- a/axiom_spi_comms.c
+++ b/axiom_spi_comms.c
@@ -27,6 +27,7 @@
 #include <linux/pm.h>
 #include <linux/spi/spi.h>
 #include <linux/string.h>
+#include <linux/version.h>
 #include "axiom_core.h"
 
 #define COMMS_HEADER_LENGTH      (4U)
@@ -241,7 +242,11 @@ static int axiom_spi_probe(struct spi_device *spi)
 }
 
 // purpose: Clean-up when device is disconnected
+#if(LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0))
+static int axiom_spi_remove(struct spi_device *spi)
+#else
 static void axiom_spi_remove(struct spi_device *spi)
+#endif
 {
 	struct axiom_data *data;
 	struct axiom_data_core *data_core;
@@ -258,6 +263,10 @@ static void axiom_spi_remove(struct spi_device *spi)
 	axiom_remove(data_core);
 
 	dev_info(&spi->dev, "Removed\n");
+
+#if(LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0))
+	return 0;
+#endif
 }
 
 static const struct spi_device_id axiom_spi_id_table[] = {

--- a/axiom_spi_comms.c
+++ b/axiom_spi_comms.c
@@ -242,7 +242,7 @@ static int axiom_spi_probe(struct spi_device *spi)
 }
 
 // purpose: Clean-up when device is disconnected
-#if(LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0))
+#if (KERNEL_VERSION(5, 18, 0) > LINUX_VERSION_CODE)
 static int axiom_spi_remove(struct spi_device *spi)
 #else
 static void axiom_spi_remove(struct spi_device *spi)
@@ -264,7 +264,7 @@ static void axiom_spi_remove(struct spi_device *spi)
 
 	dev_info(&spi->dev, "Removed\n");
 
-#if(LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0))
+#if (KERNEL_VERSION(5, 18, 0) > LINUX_VERSION_CODE)
 	return 0;
 #endif
 }


### PR DESCRIPTION
added checks for versions of the kernel where api changes for the .remove() function were identified (v5.18 for spi, v6.1 for i2c). 
'checkpatch.pl' has been run and errors resolved - outstanding warnings are that 'LINUX_VERSION_CODE' should be avoided, and that device tree compatible strings are undocumented. 